### PR TITLE
Re-enable rust-analyzer `non_snake_case`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,4 @@
 {
-    "rust-analyzer.diagnostics.disabled": [
-        "non_snake_case" // false positive in when expr with generated #[allow(non_snake_case)]
-    ],
     // format Zng macros too
     "rust-analyzer.rustfmt.overrideCommand": [
         "cargo",


### PR DESCRIPTION
False positive is fixed.

## Manual Tests

<!-- Test each entry using the binaries artifacts provided by the CI test run  -->

- [ ] Ubuntu portable
- [ ] Ubuntu deb install
- [ ] Windows portable
- [ ] Windows setup
- [ ] macOS dmg install
- [ ] Android apk install