### PR TITLE
Fix cargo do run-r

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["crates/*", "tools/*"]
 default-members = ["crates/*"]
 
 [profile.release]
-# use `cargo do build-r` or `cargo do run-r` to build with release features.
+# use `cargo do build-release` or `cargo do run-release` to build with release features.
 lto = "fat"
 codegen-units = 1
 

--- a/pack/README.md
+++ b/pack/README.md
@@ -13,7 +13,7 @@ Not a full package, just groups bin and res in an easy place for other packages 
 
 **portable**
 
-Portable app folder, app should be executable from a flash drive (on the target OS). Used by `cargo do run-r`.
+Portable app folder, app should be executable from a flash drive (on the target OS). Used by `cargo do run-release`.
 
 **portable-tar**
 


### PR DESCRIPTION
Also add an error for `cargo do run|build --release`, these commands just redirect to the basic cargo command and do not handle the release features properly.

## Manual Tests

<!-- Test each entry using the binaries artifacts provided by the CI test run  -->

- [ ] Ubuntu portable
- [ ] Ubuntu deb install
- [ ] Windows portable
- [ ] Windows setup
- [ ] macOS dmg install
- [ ] Android apk install