### PR TITLE
Improve read-only config setup

### DIFF
--- a/crates/shared/src/config.rs
+++ b/crates/shared/src/config.rs
@@ -10,12 +10,12 @@ const SETTINGS_FILE: &str = "settings.json";
 /// Initialize user config in the app context.
 pub fn app_init() {
     // configs the user does not edit directly
-    let default_config = ReadOnlyConfig::new(FileConfig::sync(zng::env::res(CONFIG_FILE)));
+    let default_config = FileConfig::read(zng::env::res(CONFIG_FILE));
     let user_config = FileConfig::sync(zng::env::config(CONFIG_FILE));
     let config = FallbackConfig::new(user_config, default_config);
 
     // configs the user edits directly (all keys with "settings." prefix)
-    let default_settings = ReadOnlyConfig::new(FileConfig::sync(zng::env::res(SETTINGS_FILE)));
+    let default_settings = FileConfig::read(zng::env::res(SETTINGS_FILE));
     let user_settings = FileConfig::sync(zng::env::config(SETTINGS_FILE));
     let settings = FallbackConfig::new(user_settings, default_settings);
 


### PR DESCRIPTION
## Manual Tests

<!-- Test each entry using the binaries artifacts provided by the CI test run  -->

- [ ] Ubuntu portable
- [ ] Ubuntu deb install
- [ ] Windows portable
- [ ] Windows setup
- [ ] macOS dmg install
- [ ] Android apk install

This can only be merged after [0.16.7](https://github.com/zng-ui/zng/milestone/85).