### PR TITLE
Fix cargo-about error

### DIFF
--- a/.cargo/about.toml
+++ b/.cargo/about.toml
@@ -19,5 +19,4 @@ accepted = [
 
 ignore-build-dependencies = true
 ignore-dev-dependencies = true
-filter-noassertion = true
 private = { ignore = true }


### PR DESCRIPTION
They removed `filter-noassertion`

## Manual Tests

<!-- Test each entry using the binaries artifacts provided by the CI test run  -->

- [ ] Ubuntu portable
- [ ] Ubuntu deb install
- [ ] Windows portable
- [ ] Windows setup
- [ ] macOS dmg install
- [ ] Android apk install